### PR TITLE
Resolved mismatch stubbings in ApproveStepTest.java

### DIFF
--- a/src/test/java/org/thoughtslive/jenkins/plugins/hubot/steps/ApproveStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/hubot/steps/ApproveStepTest.java
@@ -63,9 +63,6 @@ public class ApproveStepTest {
     when(hubotServiceMock.sendMessage(any()))
         .thenReturn(builder.successful(true).code(200).message("Success").build());
 
-    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
-    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:9090/hubot-testing/job/01");
-
     when(contextMock.get(Run.class)).thenReturn(runMock);
     when(contextMock.get(TaskListener.class)).thenReturn(taskListenerMock);
     when(contextMock.get(EnvVars.class)).thenReturn(envVarsMock);
@@ -78,6 +75,8 @@ public class ApproveStepTest {
 
   @Test
   public void testWithEmptyHubotURLThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
     final ApproveStep step = new ApproveStep("message");
     step.setRoom("room");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);
@@ -96,6 +95,8 @@ public class ApproveStepTest {
 
   @Test
   public void testWithEmptyRoomThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_DEFAULT_ROOM")).thenReturn(null);
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
     final ApproveStep step = new ApproveStep("message");
     step.setUrl("http://localhost:9090/");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);
@@ -111,6 +112,8 @@ public class ApproveStepTest {
 
   @Test
   public void testWithEmptyMessageThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:9090/hubot-testing/job/01");
     final ApproveStep step = new ApproveStep("");
     step.setRoom("");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);
@@ -125,6 +128,9 @@ public class ApproveStepTest {
 
   @Test
   public void testErrorMessageSend() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
+    when(envVarsMock.get("CHANGE_AUTHOR")).thenReturn(null);
     final ApproveStep step = new ApproveStep("message");
     step.setRoom("room");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);
@@ -142,6 +148,8 @@ public class ApproveStepTest {
 
   @Test
   public void testFailOnErrorFalseDoesNotThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_DEFAULT_ROOM")).thenReturn(null);
     final ApproveStep step = new ApproveStep("message");
     step.setFailOnError("false");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);
@@ -156,6 +164,9 @@ public class ApproveStepTest {
 
   @Test
   public void testSuccessfulMessageSend() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
+    when(envVarsMock.get("CHANGE_AUTHOR")).thenReturn(null);
     final ApproveStep step = new ApproveStep("message");
     step.setRoom("room");
     stepExecution = new ApproveStep.ApproveStepExecution(step, contextMock);


### PR DESCRIPTION
# Description

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testWithEmptyHubotURLThrowsAbortException`:

* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in a mismatch stubbing

In the test `testWithEmptyRoomThrowsAbortException`:

* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"HUBOT_URL"`
ii) is also stubbed in the `setup` method with argument `"BUILD_URL"`
iii) during test execution the method is actually called with argument `"HUBOT_DEFAULT_ROOM"`, resulting in a mismatch stubbing
iv) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in another mismatch stubbing

In the tests `testErrorMessageSend` and `testSuccessfulMessageSend`:
* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in a mismatch stubbing
iii) during test execution the method is actually called with argument `"CHANGE_AUTHOR"`, resulting in another mismatch stubbing

 In the test `testFailOnErrorFalseDoesNotThrowsAbortException`:
* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_DEFAULT_ROOM"`, resulting in a mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate. (Not applicable)
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests. (Not applicable)
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given